### PR TITLE
labels should not contain the 'for' HTML attribute when readonly

### DIFF
--- a/app/builders/ndr_ui/bootstrap/readonly.rb
+++ b/app/builders/ndr_ui/bootstrap/readonly.rb
@@ -54,7 +54,7 @@ module NdrUi
           # For labels, the for attribute should be removed:
           def label(method, text = nil, **options, &block)
             return super unless readonly?
-            super(object_name, method, (options || {}).merge(for: nil), &block)
+            super(object_name, method, options.merge(for: nil), &block)
           end
 
           # radio_button takes another intermediate argument:

--- a/app/builders/ndr_ui/bootstrap/readonly.rb
+++ b/app/builders/ndr_ui/bootstrap/readonly.rb
@@ -9,8 +9,8 @@ module NdrUi
     module Readonly
       def self.included(base)
         # These have different signatures, or aren't affected by `readonly`:
-        not_affected = [:label, :fields_for]
-        needs_custom = [:radio_button, :file_field, :hidden_field] +
+        not_affected = [:fields_for]
+        needs_custom = [:label, :radio_button, :file_field, :hidden_field] +
                        base.field_helpers_from_form_options_helper
 
         (base.field_helpers - needs_custom - not_affected).each do |selector|
@@ -49,6 +49,12 @@ module NdrUi
             return super unless readonly?
             readonly_value = options.symbolize_keys.fetch(:readonly_value, object.send(method))
             @template.content_tag(:p, readonly_value, class: 'form-control-static')
+          end
+
+          # For labels, the for attribute should be removed:
+          def label(method, text = nil, **options, &block)
+            return super unless readonly?
+            super(object_name, method, (options || {}).merge(for: nil), &block)
           end
 
           # radio_button takes another intermediate argument:

--- a/test/builders/ndr_ui/bootstrap_builder/readonly_test.rb
+++ b/test/builders/ndr_ui/bootstrap_builder/readonly_test.rb
@@ -102,4 +102,19 @@ class ReadonlyTest < ActionView::TestCase
     assert_select 'input[type=hidden]#post_created_at', 0
     assert_select 'p.form-control-static', 0
   end
+
+  test 'readonly label should not display for attribute' do
+    time = Time.current
+    post = Post.new(created_at: time)
+
+    bootstrap_form_for post do |form|
+      assert_dom_equal '<label for="post_created_at">Created at</label>',
+                       form.label(:created_at, 'Created at')
+    end
+
+    bootstrap_form_for post, readonly: true do |form|
+      assert_dom_equal '<label>Created at</label>',
+                       form.label(:created_at, 'Created at')
+    end
+  end
 end


### PR DESCRIPTION
This is because no element with that id exists (values are rendered as text instead of within form input elements). This results in more conformant HTML and reduces the page size a little.