### PR TITLE
added a test suite that should wrap help-block for fields inside fields_for collection

### DIFF
--- a/test/builders/ndr_ui/bootstrap_builder/inline_errors_and_warnings_test.rb
+++ b/test/builders/ndr_ui/bootstrap_builder/inline_errors_and_warnings_test.rb
@@ -37,6 +37,33 @@ class InlineErrorsAndWarningsTest < ActionView::TestCase
     end
   end
 
+  test 'should wrap help-block when fields_for a collections' do
+    post = Post.new
+
+    form_for post do |form|
+      assert_dom_equal(
+        '<input type="text" name="post[sub_records][][created_at]" id="post_sub_records__created_at" />',
+        form.fields_for('sub_records[]', Post.new) do |sub_form|
+          sub_form.text_field(:created_at)
+        end
+      )
+    end
+
+    bootstrap_form_for post do |form|
+      assert_dom_equal(
+        '<input class="form-control" type="text" name="post[sub_records][][created_at]" id="post_sub_records__created_at" />' \
+        '<span class="help-block" data-feedback-for="post_sub_records__created_at">' \
+        '<span class="text-danger"></span>' \
+        '<span class="text-warning"></span>' \
+        '</span>',
+
+        form.fields_for('sub_records[]', Post.new) do |sub_form|
+          sub_form.text_field(:created_at)
+        end
+      )
+    end
+  end
+
   test 'should display warnings' do
     post = Post.new
     post.warnings[:created_at] << 'some' << 'message'


### PR DESCRIPTION
As discussed with @joshpencheon , I wrote a test suite to reproduce the scenario that how `NdrUi::BootstrapBuilder` breaks when the `fields_for` is for a collection, as a compare to `ActionView::Helpers::FormBuilder` behaviour.

The test is currently break. The error back tracing to: ` HelpBlock.new` in `app/builders/ndr_ui/bootstrap/inline_errors_and_warnings.rb`

```
L7:
class HelpBlock < ActionView::Helpers::Tags::Base
end

L45
def inline_errors_and_warnings(method)
    HelpBlock.new(object_name, method, @template, options).render do
    end
end
```