### PR TITLE
input-group-addon style change on readonly forms

### DIFF
--- a/app/assets/stylesheets/ndr_ui/index.scss
+++ b/app/assets/stylesheets/ndr_ui/index.scss
@@ -9,3 +9,11 @@
         display: table-cell;
     }
 }
+
+// for input fields with input-addons, remove background and border when the form is readonly. 
+.input-group {
+  .form-control-static + .input-group-addon {
+    background: none;
+    border:0;
+  }
+}


### PR DESCRIPTION
 for input fields with input-addons, remove background and border when the form is read-only. 

sign off by @timgentry.