### PR TITLE
# Add data-confirm to delete_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
-
+### Changed
+* `delete_link` now adds a `data-confirm` attribute by default (#25)
 ## 1.12.2 / 2018-06-22
 ### Fixed
 * Address issue with datepicker SCSS (#22)

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -438,14 +438,11 @@ module NdrUi
     def delete_link(path, options = {})
       defaults = {
         icon: 'trash icon-white', title: 'Delete', path: path,
-        class: 'btn btn-xs btn-danger', method: :delete
+        class: 'btn btn-xs btn-danger', method: :delete,
+        'data-confirm': 'Are you sure you want to delete this?'
       }
 
-      data_attrs = options.fetch(:data, {}).reverse_merge(
-        confirm: 'Are you sure you want to delete this?'
-      )
-
-      link_to_with_icon(defaults.merge(options.merge(data: data_attrs)))
+      link_to_with_icon(defaults.merge(options))
     end
 
     # Creates a Boostrap link with icon.

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -431,13 +431,21 @@ module NdrUi
     # ==== Examples
     #
     #   <%= delete_link('#') %>
-    #   # => <a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"
-    #           data-method="delete" href="#">
+    #   # => <a title="Delete" class="btn btn-xs btn-danger" rel="nofollow" href="#"
+    #           data-method="delete" data-confirm="Are you sure you want to delete this?">
     #          <span class="glyphicon glyphicon-trash icon-white"></span>
     #        </a>'
     def delete_link(path, options = {})
-      link_to_with_icon({ icon: 'trash icon-white', title: 'Delete', path: path,
-                          class: 'btn btn-xs btn-danger', method: :delete }.merge(options))
+      defaults = {
+        icon: 'trash icon-white', title: 'Delete', path: path,
+        class: 'btn btn-xs btn-danger', method: :delete
+      }
+
+      data_attrs = options.fetch(:data, {}).reverse_merge(
+        confirm: 'Are you sure you want to delete this?'
+      )
+
+      link_to_with_icon(defaults.merge(options.merge(data: data_attrs)))
     end
 
     # Creates a Boostrap link with icon.

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -432,14 +432,14 @@ module NdrUi
     #
     #   <%= delete_link('#') %>
     #   # => <a title="Delete" class="btn btn-xs btn-danger" rel="nofollow" href="#"
-    #           data-method="delete" data-confirm="Are you sure you want to delete this?">
+    #           data-method="delete" data-confirm="Are you sure?">
     #          <span class="glyphicon glyphicon-trash icon-white"></span>
     #        </a>'
     def delete_link(path, options = {})
       defaults = {
         icon: 'trash icon-white', title: 'Delete', path: path,
         class: 'btn btn-xs btn-danger', method: :delete,
-        'data-confirm': 'Are you sure you want to delete this?'
+        'data-confirm': I18n.translate(:'ndr_ui.confirm_delete', locale: options[:locale])
       }
 
       link_to_with_icon(defaults.merge(options))

--- a/lib/ndr_ui.rb
+++ b/lib/ndr_ui.rb
@@ -4,3 +4,7 @@ require 'ndr_ui/engine'
 # Any NdrUi configuration or convenience methods should go here
 module NdrUi
 end
+
+ActiveSupport.on_load(:i18n) do
+  I18n.load_path << File.expand_path("ndr_ui/locale/en.yml", __dir__)
+end

--- a/lib/ndr_ui.rb
+++ b/lib/ndr_ui.rb
@@ -6,5 +6,5 @@ module NdrUi
 end
 
 ActiveSupport.on_load(:i18n) do
-  I18n.load_path << File.expand_path("ndr_ui/locale/en.yml", __dir__)
+  I18n.load_path << File.expand_path('ndr_ui/locale/en.yml', __dir__)
 end

--- a/lib/ndr_ui/locale/en.yml
+++ b/lib/ndr_ui/locale/en.yml
@@ -1,0 +1,3 @@
+en:
+  ndr_ui:
+    confirm_delete: 'Are you sure?'

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -280,7 +280,16 @@ module NdrUi
     test 'bootstrap_delete_link' do
       actual = delete_link('#')
       expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \
-                 ' data-method="delete" href="#">' \
+                 ' data-method="delete" href="#" data-confirm="Are you sure you' \
+                 ' want to delete this?">' \
+                 '<span class="glyphicon glyphicon-trash icon-white"></span></a>'
+      assert_dom_equal expected, actual
+    end
+
+    test 'bootstrap_delete_link with custom confirm' do
+      actual = delete_link('#', data: { confirm: 'Really?' })
+      expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \
+                 ' data-method="delete" href="#" data-confirm="Really?">' \
                  '<span class="glyphicon glyphicon-trash icon-white"></span></a>'
       assert_dom_equal expected, actual
     end

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -280,8 +280,7 @@ module NdrUi
     test 'bootstrap_delete_link' do
       actual = delete_link('#')
       expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \
-                 ' data-method="delete" href="#" data-confirm="Are you sure you' \
-                 ' want to delete this?">' \
+                 ' data-method="delete" href="#" data-confirm="Are you sure?">' \
                  '<span class="glyphicon glyphicon-trash icon-white"></span></a>'
       assert_dom_equal expected, actual
     end

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -287,7 +287,7 @@ module NdrUi
     end
 
     test 'bootstrap_delete_link with custom confirm' do
-      actual = delete_link('#', data: { confirm: 'Really?' })
+      actual = delete_link('#', 'data-confirm': 'Really?')
       expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \
                  ' data-method="delete" href="#" data-confirm="Really?">' \
                  '<span class="glyphicon glyphicon-trash icon-white"></span></a>'


### PR DESCRIPTION
We often add this `data-confirm` message to delete links when using `ndr_ui`; it would be nice just to add it as the default (overridable) behaviour.

@timgentry ?