### PR TITLE
Link authorisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 ### Changed
 * `delete_link` now adds a `data-confirm` attribute by default (#25)
+* `{details,edit,delete}_link` integrate with authorisation, if possible (#26)
+
 ## 1.12.2 / 2018-06-22
 ### Fixed
 * Address issue with datepicker SCSS (#22)

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -479,7 +479,15 @@ module NdrUi
     # If an authorisation provider (i.e. CanCan) exists, use it:
     def ndr_can?(action, subject, *extra_args)
       return true unless respond_to?(:can?)
-      return true unless subject.is_a?(ActiveRecord::Base)
+
+      unless subject.is_a?(ActiveRecord::Base)
+        ActiveSupport::Deprecation.warn(<<~MSG)
+          Attempting to authorise a non-resource object causes authorisation to be skipped.
+          In future, this behaviour may change; please use a resource where possible.
+        MSG
+
+        return true
+      end
 
       can?(action, subject, *extra_args)
     end

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -402,6 +402,8 @@ module NdrUi
     #        </a>
     #
     def details_link(path, options = {})
+      return unless ndr_can?(:read, path)
+
       link_to_with_icon({ icon: 'share-alt', title: 'Details', path: path }.merge(options))
     end
 
@@ -419,6 +421,10 @@ module NdrUi
     #        </a>
     #
     def edit_link(path, options = {})
+      return unless ndr_can?(:edit, path)
+
+      path = edit_polymorphic_path(path) if path.is_a?(ActiveRecord::Base)
+
       link_to_with_icon({ icon: 'pencil', title: 'Edit', path: path }.merge(options))
     end
 
@@ -436,6 +442,8 @@ module NdrUi
     #          <span class="glyphicon glyphicon-trash icon-white"></span>
     #        </a>'
     def delete_link(path, options = {})
+      return unless ndr_can?(:delete, path)
+
       defaults = {
         icon: 'trash icon-white', title: 'Delete', path: path,
         class: 'btn btn-xs btn-danger', method: :delete,
@@ -465,5 +473,15 @@ module NdrUi
     end
 
     # TODO: bootstrap_will_paginate(collection = nil, options = {})
+
+    private
+
+    # If an authorisation provider (i.e. CanCan) exists, use it:
+    def ndr_can?(action, subject, *extra_args)
+      return true unless respond_to?(:can?)
+      return true unless subject.is_a?(ActiveRecord::Base)
+
+      can?(action, subject, *extra_args)
+    end
   end
 end

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -264,17 +264,48 @@ module NdrUi
     end
 
     test 'bootstrap_details_link' do
-      actual = details_link('#')
+      actual   = details_link('#')
       expected = '<a title="Details" class="btn btn-default btn-xs" href="#">' \
                  '<span class="glyphicon glyphicon-share-alt"></span></a>'
+
       assert_dom_equal expected, actual
     end
 
+    test 'bootstrap_details_link with resource' do
+      post     = Post.create
+      actual   = details_link(post)
+      expected = '<a title="Details" class="btn btn-default btn-xs" href="/posts/%<id>d">' \
+                 '<span class="glyphicon glyphicon-share-alt"></span></a>'
+
+      assert_dom_equal format(expected, id: post.id), actual
+    end
+
+    test 'bootstrap_details_link with forbidden resource' do
+      post = Post.create
+      stubs(:can?).with(:read, post).returns(false)
+
+      assert_nil details_link(post)
+    end
+
     test 'bootstrap_edit_link' do
-      actual = edit_link('#')
+      actual   = edit_link('#')
       expected = '<a title="Edit" class="btn btn-default btn-xs" href="#">' \
                  '<span class="glyphicon glyphicon-pencil"></span></a>'
       assert_dom_equal expected, actual
+    end
+
+    test 'bootstrap_edit_link with resource' do
+      post     = Post.create
+      actual   = edit_link(post)
+      expected = '<a title="Edit" class="btn btn-default btn-xs" href="/posts/%<id>d/edit">' \
+                 '<span class="glyphicon glyphicon-pencil"></span></a>'
+      assert_dom_equal format(expected, id: post.id), actual
+    end
+
+    test 'bootstrap_edit_link with forbidden resource' do
+      post = Post.create
+      stubs(:can?).with(:edit, post).returns(false)
+      assert_nil edit_link(post)
     end
 
     test 'bootstrap_delete_link' do
@@ -283,6 +314,22 @@ module NdrUi
                  ' data-method="delete" href="#" data-confirm="Are you sure?">' \
                  '<span class="glyphicon glyphicon-trash icon-white"></span></a>'
       assert_dom_equal expected, actual
+    end
+
+    test 'bootstrap_delete_link with resource' do
+      post   = Post.create
+      actual = delete_link(post)
+      expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \
+                 ' data-method="delete" href="/posts/%<id>d"' \
+                 ' data-confirm="Are you sure?">' \
+                 '<span class="glyphicon glyphicon-trash icon-white"></span></a>'
+      assert_dom_equal format(expected, id: post.id), actual
+    end
+
+    test 'bootstrap_delete_link with forbidden resource' do
+      post = Post.create
+      stubs(:can?).with(:delete, post).returns(false)
+      assert_nil delete_link(post)
     end
 
     test 'bootstrap_delete_link with custom confirm' do

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -332,6 +332,20 @@ module NdrUi
       assert_nil delete_link(post)
     end
 
+    test 'non authorisable link with non-resource is not deprecated' do
+      assert_not_deprecated { details_link('#') }
+    end
+
+    test 'authorisable link with non-resource is deprecated' do
+      stubs(can?: true)
+
+      actual   = assert_deprecated(/authorise a non-resource object/) { details_link('#') }
+      expected = '<a title="Details" class="btn btn-default btn-xs" href="#">' \
+                 '<span class="glyphicon glyphicon-share-alt"></span></a>'
+
+      assert_equal expected, actual
+    end
+
     test 'bootstrap_delete_link with custom confirm' do
       actual = delete_link('#', 'data-confirm': 'Really?')
       expected = '<a title="Delete" class="btn btn-xs btn-danger" rel="nofollow"' \


### PR DESCRIPTION
Once #25 has been decided upon, this PR would allow `details_link` / `edit_link` / `delete_link` to integrate with an authorisation provider (e.g. `CanCan`) if it is available in the project, and if the methods are called with resource instances:

```ruby
# can authorise:
edit_link(@post)

# cannot authorise:
edit_link(controller: 'posts', action: 'edit', id: @post.id)
```

The behaviour should be otherwise unchanged. I've used a private method, `ndr_can?`, to do the authorisation check, but am conscious it's not brilliantly named - so would be open to suggestions!