### PR TITLE
Add `inline_controls_for`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * `delete_link` now adds a `data-confirm` attribute by default (#25)
 * `{details,edit,delete}_link` integrate with authorisation, if possible (#26)
 
+### Added
+* Add `inline_controls_for` button toolbar helper (#27)
+
 ## 1.12.2 / 2018-06-22
 ### Fixed
 * Address issue with datepicker SCSS (#22)

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -470,8 +470,8 @@ module NdrUi
 
       groups << delete_link(object)
 
-      group = [edit_link(object, options), details_link(object, options)]
-      groups << safe_join(group) if group.any?
+      main_group = [edit_link(object, options), details_link(object, options)]
+      groups << safe_join(main_group) if main_group.any?
 
       groups.compact!
       groups.map! { |group| button_group { group } }

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -453,6 +453,32 @@ module NdrUi
       link_to_with_icon(defaults.merge(options))
     end
 
+    # Creates a Boostrap inline menu, with show/edit/delete links.
+    # If possibly, conditionally checks permissions
+    #
+    # ==== Signatures
+    #
+    #   inline_controls_for(object, options = {})
+    #
+    # ==== Examples
+    #
+    #   # creates: [ [delete] ] [ [edit] [details] ]
+    #   <%= inline_controls_for(@post) %>
+    #
+    def inline_controls_for(object, options = {})
+      groups = []
+
+      groups << delete_link(object)
+
+      group = [edit_link(object, options), details_link(object, options)]
+      groups << safe_join(group) if group.any?
+
+      groups.compact!
+      groups.map! { |group| button_group { group } }
+
+      button_toolbar { safe_join(groups) } if groups.any?
+    end
+
     # Creates a Boostrap link with icon.
     #
     # ==== Signatures

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -354,6 +354,46 @@ module NdrUi
       assert_dom_equal expected, actual
     end
 
+    test 'inline_controls_for resource' do
+      post = Post.create
+
+      actual   = inline_controls_for(post)
+      expected =
+        '<div class="btn-toolbar"><div class="btn-group"><a title="Delete"' \
+        ' class="btn btn-xs btn-danger" data-confirm="Are you sure you want to' \
+        ' delete this?" rel="nofollow" data-method="delete" href="/posts/1">' \
+        '<span class="glyphicon glyphicon-trash icon-white"></span></a></div>' \
+        '<div class="btn-group"><a title="Edit" class="btn btn-default btn-xs"' \
+        ' href="/posts/1/edit"><span class="glyphicon glyphicon-pencil"></span></a>' \
+        '<a title="Details" class="btn btn-default btn-xs" href="/posts/1">' \
+        '<span class="glyphicon glyphicon-share-alt"></span></a></div></div>'
+
+      assert_dom_equal expected, actual
+    end
+
+    test 'inline_controls_for limited resource' do
+      post = Post.create
+
+      stubs(:can?).with(:read, post).returns(true)
+      stubs(:can?).with(:edit, post).returns(false)
+      stubs(:can?).with(:delete, post).returns(false)
+
+      actual   = inline_controls_for(post)
+      expected =
+        '<div class="btn-toolbar"><div class="btn-group">' \
+        '<a title="Details" class="btn btn-default btn-xs" href="/posts/1">' \
+        '<span class="glyphicon glyphicon-share-alt"></span></a></div></div>'
+
+      assert_dom_equal expected, actual
+    end
+
+    test 'inline_controls_for forbidden resource' do
+      post = Post.create
+      stubs(can?: false)
+
+      assert_nil inline_controls_for(post)
+    end
+
     test 'bootstrap_link_to_with_icon' do
       actual = link_to_with_icon(icon: 'trash icon-white', title: 'Delete', path: '#')
       expected = '<a title="Delete" class="btn btn-default btn-xs" href="#">' \

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -360,8 +360,8 @@ module NdrUi
       actual   = inline_controls_for(post)
       expected =
         '<div class="btn-toolbar"><div class="btn-group"><a title="Delete"' \
-        ' class="btn btn-xs btn-danger" data-confirm="Are you sure you want to' \
-        ' delete this?" rel="nofollow" data-method="delete" href="/posts/1">' \
+        ' class="btn btn-xs btn-danger" data-confirm="Are you sure?"' \
+        ' rel="nofollow" data-method="delete" href="/posts/1">' \
         '<span class="glyphicon glyphicon-trash icon-white"></span></a></div>' \
         '<div class="btn-group"><a title="Edit" class="btn btn-default btn-xs"' \
         ' href="/posts/1/edit"><span class="glyphicon glyphicon-pencil"></span></a>' \


### PR DESCRIPTION
Once #25 and #26 have been decided upon, this upstreams a single method `inline_controls_for`, which we have used to provide consistent controls for entities on e.g. table rows. It might be nice to have that consistency across projects.