### PR TITLE
Make BootstrapBuilder works with form_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Changed
+* `form_with` can use `NdrUi::BootstrapBuilder` as builder, also added `bootstrap_form_with` helper method as shortcut (#32)
 * for input fields with `input-addons`, remove background and border when the form is read-only. (#24)
 * `delete_link` now adds a `data-confirm` attribute by default (#25)
 * `{details,edit,delete}_link` integrate with authorisation, if possible (#26)

--- a/app/builders/ndr_ui/bootstrap/label_tooltips.rb
+++ b/app/builders/ndr_ui/bootstrap/label_tooltips.rb
@@ -46,11 +46,13 @@ module NdrUi
         scope        = 'tooltips'
         search_paths = ["#{scope}.#{attribute}"]
 
-        @object.class.lookup_ancestors.map do |ancestor|
-          search_paths.unshift("#{scope}.#{ancestor.model_name.i18n_key}.#{attribute}")
-        end
+        if @object.present?
+          @object.class.lookup_ancestors.map do |ancestor|
+            search_paths.unshift("#{scope}.#{ancestor.model_name.i18n_key}.#{attribute}")
+          end
 
-        search_paths.unshift("#{scope}.#{@object.class.model_name.i18n_key}.#{attribute}")
+          search_paths.unshift("#{scope}.#{@object.class.model_name.i18n_key}.#{attribute}")
+        end
 
         search_paths.map!(&:to_sym)
 

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -248,12 +248,14 @@ module NdrUi
     def bootstrap_form_with(*args, &proc)
       options = args.extract_options!
       options[:html] ||= {}
+      horizontal = options.delete(:horizontal)
 
       # :horizontal
-      if horizontal = options.delete(:horizontal)
+      if horizontal
         # set the form html class for horizontal bootstrap forms
         options[:html][:class] ||= ''
-        options[:html][:class] = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
+        classes = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
+        options[:html][:class] = classes
       end
 
       # We switch autocomplete off by default

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -245,9 +245,9 @@ module NdrUi
 
     # Identical signature to form_with, but uses NdrUi::BootstrapBuilder.
     # See ActionView::Helpers::FormHelper for details
-    def bootstrap_form_with(*args, &proc)
-      options = args.extract_options!
+    def bootstrap_form_with(**options, &block)
       options[:html] ||= {}
+      options[:builder] = NdrUi::BootstrapBuilder
       horizontal = options.delete(:horizontal)
 
       # :horizontal
@@ -262,12 +262,12 @@ module NdrUi
       raise 'autocomplete should be defined an html option' if options[:autocomplete]
       options[:html][:autocomplete] ||= 'off'
 
-      form_with(*(args << options.merge(builder: NdrUi::BootstrapBuilder))) do |form|
+      form_with(**options) do |form|
         # Put the form builder into horizontal mode (if necessary)
         form.horizontal_mode = horizontal if horizontal
 
         # yield to the provided form block
-        yield(form)
+        block.call(form)
       end
     end
 

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -243,6 +243,32 @@ module NdrUi
       end
     end
 
+    # Identical signature to form_with, but uses NdrUi::BootstrapBuilder.
+    # See ActionView::Helpers::FormHelper for details
+    def bootstrap_form_with(*args, &proc)
+      options = args.extract_options!
+      options[:html] ||= {}
+
+      # :horizontal
+      if horizontal = options.delete(:horizontal)
+        # set the form html class for horizontal bootstrap forms
+        options[:html][:class] ||= ''
+        options[:html][:class] = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
+      end
+
+      # We switch autocomplete off by default
+      raise 'autocomplete should be defined an html option' if options[:autocomplete]
+      options[:html][:autocomplete] ||= 'off'
+
+      form_with(*(args << options.merge(builder: NdrUi::BootstrapBuilder))) do |form|
+        # Put the form builder into horizontal mode (if necessary)
+        form.horizontal_mode = horizontal if horizontal
+
+        # yield to the provided form block
+        yield(form)
+      end
+    end
+
     # TODO: bootstrap_pagination_tag(*args, &block)
 
     # Creates a Boostrap control group for button.

--- a/test/builders/ndr_ui/bootstrap_builder/label_tooltips_test.rb
+++ b/test/builders/ndr_ui/bootstrap_builder/label_tooltips_test.rb
@@ -22,6 +22,23 @@ class LabelTooltipsTest < ActionView::TestCase
     assert_select 'label[for=post_created_at]'
   end
 
+  test 'should include tooltips when translations exist - nil model object' do
+    NdrUi::BootstrapBuilder.any_instance.stubs(:display?).returns(true)
+
+    I18n.expects(:translate).
+      with(:'tooltips.bomb', raise: true, default: []).
+      returns('Dangerous')
+
+    @output_buffer =
+      form_with(url: '/', builder: NdrUi::BootstrapBuilder) do |form|
+        form.label :bomb, 'Test'
+      end
+
+    assert_select 'span.question-tooltip[title=Dangerous]'
+    assert_select 'label'
+    assert_select 'label[for=?]', /.+/, 0
+  end
+
   test 'should not include tooltips when there is no translation' do
     post = Post.new
     NdrUi::BootstrapBuilder.any_instance.stubs(:display?).returns(true)
@@ -34,6 +51,20 @@ class LabelTooltipsTest < ActionView::TestCase
 
     assert_select '.question-tooltip', 0
     assert_select 'label[for=post_created_at]'
+  end
+
+  test 'should not include tooltips when there is no translation - nil model object' do
+    NdrUi::BootstrapBuilder.any_instance.stubs(:display?).returns(true)
+
+    @output_buffer =
+      form_with(url: '/', builder: NdrUi::BootstrapBuilder) do |form|
+        form.stubs(:translate_tooltip).returns('translation missing')
+        form.label :bomb
+      end
+
+    assert_select '.question-tooltip', 0
+    assert_select 'label'
+    assert_select 'label[for=?]', /.+/, 0
   end
 
   test 'should not include tooltips when translations is a hash' do
@@ -65,6 +96,20 @@ class LabelTooltipsTest < ActionView::TestCase
 
     assert_select '.question-tooltip[title="Not the translated value"]'
     assert_select 'label[for=post_created_at]'
+  end
+
+  test 'should allow tooltip text to be set explicitly - nil model object' do
+    NdrUi::BootstrapBuilder.any_instance.stubs(:display?).returns(true)
+
+    @output_buffer =
+      form_with(url: '/', builder: NdrUi::BootstrapBuilder) do |form|
+        form.stubs(:translate_tooltip).returns('Tooltip')
+        form.label :bomb, tooltip: 'Not the translated value'
+      end
+
+    assert_select '.question-tooltip[title="Not the translated value"]'
+    assert_select 'label'
+    assert_select 'label[for=?]', /.+/, 0
   end
 
   test 'should allow tooltips to be suppressed' do

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -183,6 +183,40 @@ module NdrUi
       end
     end
 
+    test 'bootstrap_form_with' do
+      @output_buffer = bootstrap_form_with(
+        url: posts_path,
+        html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        url: posts_path,
+        html: { id: 'preserve_me', class: 'form-inline' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me.form-inline[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        url: posts_path,
+        horizontal: true, html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me.form-horizontal[autocomplete=off][action="/posts"]'
+    end
+
+    test 'bootstrap_form_with invalid autocomplete option' do
+      assert_raise RuntimeError do
+        bootstrap_form_with(url: posts_path, autocomplete: 'on') do |form|
+          assert_kind_of BootstrapBuilder, form
+        end
+      end
+    end
+
     # TODO: bootstrap_pagination_tag(*args, &block)
 
     test 'button_control_group' do

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -185,6 +185,30 @@ module NdrUi
 
     test 'bootstrap_form_with' do
       @output_buffer = bootstrap_form_with(
+        model: Post.new,
+        html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        model: Post.new,
+        html: { id: 'preserve_me', class: 'form-inline' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me.form-inline[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        model: Post.new,
+        horizontal: true, html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me.form-horizontal[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
         url: posts_path,
         html: { id: 'preserve_me' }
       ) do |form|
@@ -210,6 +234,12 @@ module NdrUi
     end
 
     test 'bootstrap_form_with invalid autocomplete option' do
+      assert_raise RuntimeError do
+        bootstrap_form_with(model: Post.new, autocomplete: 'on') do |form|
+          assert_kind_of BootstrapBuilder, form
+        end
+      end
+
       assert_raise RuntimeError do
         bootstrap_form_with(url: posts_path, autocomplete: 'on') do |form|
           assert_kind_of BootstrapBuilder, form


### PR DESCRIPTION
# handling label_tooltip translations where model object do not exists
# added bootstrap_form_with helper method
