### PR TITLE
add stimulus data-controller options to bootstrap form helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-*no unreleased changes*
+* enable `data-controller` options to bootstrap form helpers
 
 ## 2.2.0 / 2019-07-08
 ### Added

--- a/app/helpers/ndr_ui/bootstrap_helper.rb
+++ b/app/helpers/ndr_ui/bootstrap_helper.rb
@@ -227,8 +227,14 @@ module NdrUi
       if horizontal = options.delete(:horizontal)
         # set the form html class for horizontal bootstrap forms
         options[:html][:class] ||= ''
-        options[:html][:class] = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
+        classes = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
+        options[:html][:class] = classes
       end
+
+      # stimuls controller, default `form_controller`
+      options[:html][:'data-controller'] ||= ''
+      controllers = (options[:html][:'data-controller'].split(' ') << 'form').uniq.join(' ')
+      options[:html][:'data-controller'] = controllers
 
       # We switch autocomplete off by default
       raise 'autocomplete should be defined an html option' if options[:autocomplete]
@@ -257,6 +263,11 @@ module NdrUi
         classes = (options[:html][:class].split(' ') << 'form-horizontal').uniq.join(' ')
         options[:html][:class] = classes
       end
+
+      # stimuls controller, default `form_controller`
+      options[:html][:'data-controller'] ||= ''
+      controllers = (options[:html][:'data-controller'].split(' ') << 'form').uniq.join(' ')
+      options[:html][:'data-controller'] = controllers
 
       # We switch autocomplete off by default
       raise 'autocomplete should be defined an html option' if options[:autocomplete]

--- a/test/helpers/ndr_ui/bootstrap_helper_test.rb
+++ b/test/helpers/ndr_ui/bootstrap_helper_test.rb
@@ -168,6 +168,24 @@ module NdrUi
       @output_buffer = bootstrap_form_for(
         :post,
         url: posts_path,
+        html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[data-controller=form][autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_for(
+        :post,
+        url: posts_path,
+        html: { id: 'preserve_me', 'data-controller': 'additional' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[data-controller="additional form"][autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_for(
+        :post,
+        url: posts_path,
         horizontal: true, html: { id: 'preserve_me' }
       ) do |form|
         assert_kind_of BootstrapBuilder, form
@@ -199,6 +217,22 @@ module NdrUi
         assert_kind_of BootstrapBuilder, form
       end
       assert_select 'form#preserve_me.form-inline[autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        model: Post.new,
+        html: { id: 'preserve_me' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[data-controller=form][autocomplete=off][action="/posts"]'
+
+      @output_buffer = bootstrap_form_with(
+        model: Post.new,
+        html: { id: 'preserve_me', 'data-controller': 'additional' }
+      ) do |form|
+        assert_kind_of BootstrapBuilder, form
+      end
+      assert_select 'form#preserve_me[data-controller="additional form"][autocomplete=off][action="/posts"]'
 
       @output_buffer = bootstrap_form_with(
         model: Post.new,


### PR DESCRIPTION
as the title suggested, enable data-controller options to bootstrap form helpers.

default `form_controller` is included by default.