### PR TITLE
# Change how assets are imported, and made available to the host application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Changed
+* Changes to how the engine exposes assets, for use outside of manifests
 
 ## 2.3.0 / 2019-09-03
 ### Added

--- a/app/assets/javascripts/ndr_ui/datepicker.js
+++ b/app/assets/javascripts/ndr_ui/datepicker.js
@@ -1,1 +1,1 @@
-//= require bootstrap-datepicker-1.6.0-dist/js/bootstrap-datepicker
+//= require js/bootstrap-datepicker

--- a/app/assets/javascripts/ndr_ui/timeago.js
+++ b/app/assets/javascripts/ndr_ui/timeago.js
@@ -1,4 +1,4 @@
-//= require jquery-timeago-1.5.3/jquery.timeago.js
+//= require jquery.timeago.js
 
 jQuery(document).ready(function() {
   jQuery("time.timeago,abbr.timeago").timeago();

--- a/app/assets/stylesheets/ndr_ui/datepicker.scss
+++ b/app/assets/stylesheets/ndr_ui/datepicker.scss
@@ -1,4 +1,4 @@
-@import "bootstrap-datepicker.scss";
+@import 'bootstrap-datepicker-scss-fix.scss';
 
 // Ensure date picker renders over the static nav
 .datepicker {

--- a/lib/ndr_ui/engine.rb
+++ b/lib/ndr_ui/engine.rb
@@ -6,7 +6,13 @@ module NdrUi
   class Engine < ::Rails::Engine
     isolate_namespace NdrUi
 
-    config.assets.paths << File.expand_path('../../../vendor/assets', __FILE__)
+    # Hook into host app's asset pipeline, allowing all the gem's assets
+    # to be complied alongside. This allows the gem's assets to be referenced
+    # directly by templates without issue, rather than needing to go via
+    # an asset manifest in the host.
+    initializer 'ndr_ui.assets.precompile' do |app|
+      app.config.assets.precompile += %w(*.scss *.js *.gif)
+    end
 
     # We configure the generator of the host app
     config.app_generators do |g|

--- a/vendor/assets/bootstrap-datepicker.scss
+++ b/vendor/assets/bootstrap-datepicker.scss
@@ -1,1 +1,0 @@
-./bootstrap-datepicker-1.6.0-dist/css/bootstrap-datepicker3.css

--- a/vendor/assets/datepicker-scss-fix/bootstrap-datepicker-scss-fix.scss
+++ b/vendor/assets/datepicker-scss-fix/bootstrap-datepicker-scss-fix.scss
@@ -1,0 +1,1 @@
+./../bootstrap-datepicker-1.6.0-dist/css/bootstrap-datepicker3.css


### PR DESCRIPTION
JS/CSS should now be referenceable directly from host templates. Also, change how CSS file is hackishly imported into SCSS.

@suezhou I've removed the manual tweaking of `assets.paths`, which meant a few of the internal `@imports` needed to be rewritten to use the default asset locations. Because this'll be a technically-visible change to consumers of the gem, this'll require a major version bump. Likewise, our symlink hack to be able to `@import` datepicker CSS into a SCSS file has been adjusted.