### PR TITLE
# Github should test rails 6.1, ruby 3.0.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,25 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.6
-          - 2.7
-          - 3.0
+          - '2.6'
+          - '2.7'
+          - '3.0'
         gemfile:
+          - gemfiles/Gemfile.rails52
           - gemfiles/Gemfile.rails60
-        include:
-          # Continue testing Rails 5.2 against Ruby 2.6 for now...
-        - ruby-version: 2.6
-          gemfile: gemfiles/Gemfile.rails52
-
+          # - gemfiles/Gemfile.rails61 # not yet supported
+          # - gemfiles/Gemfile.rails70 # not yet supported
+        exclude:
+          # rails 5.2 requires ruby < 3.0
+          # https://github.com/rails/rails/issues/40938
+          - ruby-version: '3.0'
+            gemfile: 'gemfiles/Gemfile.rails52'
+          - ruby-version: '3.1'
+            gemfile: 'gemfiles/Gemfile.rails52'
+          # rails 7.0 requires ruby >= 2.7
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '2.6'
+            gemfile: 'gemfiles/Gemfile.rails70'
 
     name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
 

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 6.1.0'
+

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails',  '~> 7.0.0'


### PR DESCRIPTION
# Github tests should run against ruby 3.0, not ruby 3.1.