### PR TITLE
tag v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased]
+* no unreleased changes *
+
+## 5.0.0 / 2025-01-24
+### Changed
 * Support Bootstrap to v5.3.3
 * Drop support for Bootstrap 3/4
 * include bootstrap-icons library

--- a/lib/ndr_ui/version.rb
+++ b/lib/ndr_ui/version.rb
@@ -2,5 +2,5 @@
 
 # This stores the current version of the NdrUi gem. Use semantic versioning http://semver.org
 module NdrUi
-  VERSION = '4.1.2'
+  VERSION = '5.0.0'
 end


### PR DESCRIPTION
This is a major version bump because this version may break existing code. This version supports only Bootstrap 5, and the previous version supported only Bootstrap 3.