### PR TITLE
Back-port support for Ruby 3.4, Rails 8.0 to v4.1 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,28 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         gemfile:
           - gemfiles/Gemfile.rails61
           - gemfiles/Gemfile.rails70
           - gemfiles/Gemfile.rails71
           - gemfiles/Gemfile.rails72
+          - gemfiles/Gemfile.rails80
         exclude:
+          # rails 6.1 requires ruby < 3.4
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails61'
+          # rails 7.0 requires ruby >= 2.7, < 3.4
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails70'
           # rails 7.2 requires ruby >= 3.1
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
           - ruby-version: '3.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes *
+### Fixed
+* Support Ruby 3.4, Rails 8.0
 
 ## 4.1.2 / 2025-01-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+* no unreleased changes *
+
+## 4.1.3 / 2025-11-07
 ### Fixed
 * Support Ruby 3.4, Rails 8.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,10 +14,10 @@ end
 #   rdoc.rdoc_files.include('lib/**/*.rb')
 # end
 
-load 'rails/tasks/statistics.rake'
-
-APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
+APP_RAKEFILE = File.expand_path('test/dummy/Rakefile', __dir__)
 load 'rails/tasks/engine.rake'
+
+load 'rails/tasks/statistics.rake'
 
 Bundler::GemHelper.install_tasks
 

--- a/gemfiles/Gemfile.rails80
+++ b/gemfiles/Gemfile.rails80
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails',  '~> 8.0.0'

--- a/lib/ndr_ui/version.rb
+++ b/lib/ndr_ui/version.rb
@@ -2,5 +2,5 @@
 
 # This stores the current version of the NdrUi gem. Use semantic versioning http://semver.org
 module NdrUi
-  VERSION = '4.1.2'
+  VERSION = '4.1.3'
 end

--- a/ndr_ui.gemspec
+++ b/ndr_ui.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency 'rails', '>= 6.1', '< 7.3'
+  spec.add_dependency 'rails', '>= 6.1', '< 8.1'
   spec.add_dependency 'bootstrap-sass', '~> 3.4.1'
   spec.add_dependency 'jquery-rails', '~> 4.6'
   spec.add_dependency 'sprockets', '>= 4.0'


### PR DESCRIPTION
This PR back-ports Ruby 3.4 / Rails 8.0 support to the v4.1 (bootstrap 3) branch of `ndr_ui`